### PR TITLE
Remove itimerspec from <ros/time.h>

### DIFF
--- a/kern/include/ros/time.h
+++ b/kern/include/ros/time.h
@@ -15,11 +15,6 @@ struct timespec {
 	long    tv_nsec;  /* Nanoseconds */
 };
 
-struct itimerspec {
-	struct timespec  it_interval;  /* Timer period */
-	struct timespec  it_value;     /* Timer expiration */
-};
-
 struct timeval {
 	time_t tv_sec;	/* seconds */
 	time_t tv_usec;	/* microseconds */

--- a/tests/timer_deps.c
+++ b/tests/timer_deps.c
@@ -1,0 +1,9 @@
+#include <ros/time.h>
+#include <time.h>
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+	printf("sizeof timespec: %d\n", sizeof(struct timespec));
+	return 0;
+}


### PR DESCRIPTION
Its existence causes conflicts when both <ros/time.h> and <time.h> are
\#included in the same file. We will likely want to add support for an
itimer at some point in the future, but this will never be a kernel
construct, so it's fine to pull its definition straight from <time.h>
when we go to build it. Any implementation we build will sit on the
\#alarm device and just expose the itimer interface in userspace.

We already support something "sortof" like the itimer, except its on a
per-vcore basis, rather than a per-thread basis. We can think about
actually supporting the itimer interface similarly.