### PR TITLE
Remove dependency for {unistd,stdlib}.h in vcore.h

### DIFF
--- a/tests/mcp_halt.c
+++ b/tests/mcp_halt.c
@@ -6,6 +6,7 @@
 #include <ros/bcq.h>
 #include <parlib/arch/arch.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <parlib/vcore.h>
 #include <parlib/mcs.h>
 #include <parlib/timing.h>

--- a/tests/mhello.c
+++ b/tests/mhello.c
@@ -6,6 +6,7 @@
 #include <ros/bcq.h>
 #include <parlib/arch/arch.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <parlib/vcore.h>
 #include <parlib/mcs.h>
 #include <parlib/timing.h>

--- a/tests/signal_futex.c
+++ b/tests/signal_futex.c
@@ -5,6 +5,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <parlib/parlib.h>
 #include <pthread.h>
 #include <futex.h>

--- a/tools/compilers/gcc-glibc/glibc-2.19-akaros/sysdeps/akaros/eventfd.c
+++ b/tools/compilers/gcc-glibc/glibc-2.19-akaros/sysdeps/akaros/eventfd.c
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 /* Gets a new EFD instance, returning the FD on success. */
 int eventfd(int initval, int flags)

--- a/tools/compilers/gcc-glibc/glibc-2.19-akaros/sysdeps/akaros/tls.c
+++ b/tools/compilers/gcc-glibc/glibc-2.19-akaros/sysdeps/akaros/tls.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <sys/tls.h>
 #include <parlib/vcore.h>
 #include <ldsodefs.h>

--- a/user/benchutil/pvcalarm.c
+++ b/user/benchutil/pvcalarm.c
@@ -15,6 +15,7 @@
 #include <parlib/arch/bitmask.h>
 #include <sys/queue.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <benchutil/pvcalarm.h>
 
 /* Different states for enabling/disabling the per-vcore alarms. */

--- a/user/iplib/epoll.c
+++ b/user/iplib/epoll.c
@@ -47,6 +47,8 @@
 #include <sys/user_fd.h>
 #include <stdio.h>
 #include <errno.h>
+#include <unistd.h>
+#include <malloc.h>
 
 /* Sanity check, so we can ID our own FDs */
 #define EPOLL_UFD_MAGIC 		0xe9011

--- a/user/parlib/include/vcore.h
+++ b/user/parlib/include/vcore.h
@@ -15,9 +15,9 @@ __BEGIN_DECLS
  * that properly under our vcore model (we shouldn't though).  We really need to
  * rethink what sys_yield 'should' do when in multicore mode, or else come up 
  * with a different syscall entirely. */
-#include <stdlib.h>
-#include <unistd.h>
 #undef exit
+extern void _exit (int status);
+extern void exit (int __status) __THROW __attribute__ ((__noreturn__));
 #define exit(status) _exit(status)
 /*****************************************************************************/
 

--- a/user/parlib/ucq.c
+++ b/user/parlib/ucq.c
@@ -13,6 +13,7 @@
 #include <sys/mman.h>
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <parlib/rassert.h> /* for the static_assert() */
 #include <parlib/vcore.h>
 


### PR DESCRIPTION
We only had this dependency to include the prototype for _exit() so we
could overrideour exit() call with it.  We still need to do this
override, but there is no need to pollute the namespace of everything
that #icnludes vcore.h with all of the stuff from unistd.h and stdlib.h.
Just extern in the specific _exit() prototype.

Removing this dependency meant that some of our .c files needed to
explicitly #include these files.  They are patched up accordingly.

Requires a rebuild of the cross compiler (XCC)