### PR TITLE
Fix warning in glibc-2.19/sysdeps/akaros/user_fd.c

### DIFF
--- a/tools/compilers/gcc-glibc/glibc-2.19-akaros/sysdeps/akaros/user_fd.c
+++ b/tools/compilers/gcc-glibc/glibc-2.19-akaros/sysdeps/akaros/user_fd.c
@@ -84,4 +84,5 @@ int glibc_close_helper(int fd)
 		return -1;
 	ufds[fd - USER_FD_BASE] = 0;
 	ufd->close(ufd);
+	return 0;
 }


### PR DESCRIPTION
We should explicitly return 0 at the end of this function.