### PR TITLE
Allow freeaddrinfo(NULL) (XCC)

### DIFF
--- a/tools/compilers/gcc-glibc/glibc-2.19-akaros/sysdeps/akaros/getaddrinfo.c
+++ b/tools/compilers/gcc-glibc/glibc-2.19-akaros/sysdeps/akaros/getaddrinfo.c
@@ -217,11 +217,13 @@ libc_hidden_def(getaddrinfo)
 
 void freeaddrinfo(struct addrinfo *ai)
 {
-	struct addrinfo *next = ai->ai_next;
+	struct addrinfo *next;
+	if (!ai)
+		return;
 	free(ai->ai_addr);
 	free(ai->ai_canonname);
+	next = ai->ai_next;
 	free(ai);
-	if (next)
-		freeaddrinfo(next);
+	freeaddrinfo(next);
 }
 libc_hidden_def(freeaddrinfo)


### PR DESCRIPTION
On both glibc and uclibc, freeaddrinfo(NULL) is safe, though there is no
explicit requirement for that in the spec:
http://pubs.opengroup.org/onlinepubs/009695399/functions/getaddrinfo.html

So let's change freeaddrinfo() to handle that case.

Rebuild glibc.

Signed-off-by: Xiao Jia <stfairy@gmail.com>