### PR TITLE
Net bugfixes

### DIFF
--- a/kern/src/rendez.c
+++ b/kern/src/rendez.c
@@ -67,7 +67,8 @@ void rendez_sleep_timeout(struct rendez *rv, int (*cond)(void*), void *arg,
 	struct cv_lookup_elm cle;
 	struct timer_chain *pcpui_tchain = &per_cpu_info[core_id()].tchain;
 
-	assert(usec > 0);
+	if (!usec)
+		return;
 	/* Doing this cond check early, but then unlocking again.  Mostly just to
 	 * avoid weird issues with the CV lock and the alarm tchain lock. */
 	cv_lock_irqsave(&rv->cv, &irq_state);

--- a/user/iplib/epoll.c
+++ b/user/iplib/epoll.c
@@ -158,15 +158,19 @@ static struct event_queue *ep_get_alarm_evq(void)
  * some sort of user deferred destruction. (TODO). */
 static void ep_put_ceq_evq(struct event_queue *ceq_evq)
 {
+#if 0 /* TODO: EVQ/INDIR Cleanup */
 	ceq_cleanup(&ceq_evq->ev_mbox->ceq);
 	evq_remove_wakeup_ctlr(ceq_evq);
 	put_eventq_raw(ceq_evq);
+#endif
 }
 
 static void ep_put_alarm_evq(struct event_queue *alarm_evq)
 {
+#if 0 /* TODO: EVQ/INDIR Cleanup */
 	evq_remove_wakeup_ctlr(alarm_evq);
 	put_eventq(alarm_evq);
+#endif
 }
 
 static void epoll_close(struct user_fd *ufd)

--- a/user/parlib/signal.c
+++ b/user/parlib/signal.c
@@ -74,7 +74,10 @@ static void default_term_handler(int signr, siginfo_t *info, void *ctx)
 static void default_core_handler(int signr, siginfo_t *info, void *ctx)
 {
 	fprintf(stderr, "Segmentation Fault (sorry, no core dump yet)\n");
-	print_user_context((struct user_context*)ctx);
+	if (ctx)
+		print_user_context((struct user_context*)ctx);
+	else
+		fprintf(stderr, "No ctx for %s\n", __FUNCTION__);
 	if (info) {
 		/* ghetto, we don't have access to the PF err, since we only have a few
 		 * fields available in siginfo (e.g. there's no si_trapno). */


### PR DESCRIPTION
The following changes since commit fad2f1e22bbe4a7c8d9f5fb9df7ea4f5b563bd9b:

  Allow freeaddrinfo(NULL) (XCC) (2015-10-14 17:14:45 -0400)

are available in the git repository at:

  git@github.com:brho/akaros.git net

for you to fetch changes up to d95390043f8cb4a9eac775cb99d80efe106ad8be:

  Check for ctx in default_core_handler() (2015-10-14 18:43:53 -0400)

----------------------------------------------------------------
Barret Rhoden (3):
      Handle 0 usec in rendez_sleep_timeout()
      Do not free epoll event queues
      Check for ctx in default_core_handler()

 kern/src/rendez.c    | 3 ++-
 user/iplib/epoll.c   | 4 ++++
 user/parlib/signal.c | 5 ++++-
 3 files changed, 10 insertions(+), 2 deletions(-)