### PR TITLE
r233572 patch, for GCC 6 builds

### DIFF
--- a/tools/compilers/gcc-glibc/Makefile
+++ b/tools/compilers/gcc-glibc/Makefile
@@ -358,6 +358,7 @@ gcc-$(GCC_VERSION): gcc-$(GCC_VERSION).tar.bz2 \
 	rm -rf gcc-$(GCC_VERSION)
 	tar -jxf gcc-$(GCC_VERSION).tar.bz2
 	$(MAKE) .gcc-akaros-patch
+	patch --no-backup-if-mismatch -p0 < gcc-$(GCC_VERSION)-r233572.patch
 	patch --no-backup-if-mismatch -p0 < gcc-$(GCC_VERSION)-riscv.patch
 	(cd gcc-$(GCC_VERSION) && \
 	 ln -s ../gmp-$(GMP_VERSION) gmp && \

--- a/tools/compilers/gcc-glibc/gcc-4.9.2-r233572.patch
+++ b/tools/compilers/gcc-glibc/gcc-4.9.2-r233572.patch
@@ -1,0 +1,127 @@
+Index: gcc-4.9.2/gcc/cp/Make-lang.in
+===================================================================
+--- gcc-4.9.2/gcc/cp/Make-lang.in	(revision 233574)
++++ gcc-4.9.2/gcc/cp/Make-lang.in	(working copy)
+@@ -111,7 +111,7 @@ else
+ # deleting the $(srcdir)/cp/cfns.h file.
+ $(srcdir)/cp/cfns.h:
+ endif
+-	gperf -o -C -E -k '1-6,$$' -j1 -D -N 'libc_name_p' -L ANSI-C \
++	gperf -o -C -E -k '1-6,$$' -j1 -D -N 'libc_name_p' -L C++ \
+ 		$(srcdir)/cp/cfns.gperf --output-file $(srcdir)/cp/cfns.h
+ 
+ #
+Index: gcc-4.9.2/gcc/cp/cfns.gperf
+===================================================================
+--- gcc-4.9.2/gcc/cp/cfns.gperf	(revision 233574)
++++ gcc-4.9.2/gcc/cp/cfns.gperf	(working copy)
+@@ -1,3 +1,5 @@
++%language=C++
++%define class-name libc_name
+ %{
+ /* Copyright (C) 2000-2015 Free Software Foundation, Inc.
+ 
+@@ -16,14 +18,6 @@ for more details.
+ You should have received a copy of the GNU General Public License
+ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+-#ifdef __GNUC__
+-__inline
+-#endif
+-static unsigned int hash (const char *, unsigned int);
+-#ifdef __GNUC__
+-__inline
+-#endif
+-const char * libc_name_p (const char *, unsigned int);
+ %}
+ %%
+ # The standard C library functions, for feeding to gperf; the result is used
+Index: gcc-4.9.2/gcc/cp/cfns.h
+===================================================================
+--- gcc-4.9.2/gcc/cp/cfns.h	(revision 233574)
++++ gcc-4.9.2/gcc/cp/cfns.h	(working copy)
+@@ -1,5 +1,5 @@
+-/* ANSI-C code produced by gperf version 3.0.3 */
+-/* Command-line: gperf -o -C -E -k '1-6,$' -j1 -D -N libc_name_p -L ANSI-C cfns.gperf  */
++/* C++ code produced by gperf version 3.0.4 */
++/* Command-line: gperf -o -C -E -k '1-6,$' -j1 -D -N libc_name_p -L C++ --output-file cfns.h cfns.gperf  */
+ 
+ #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
+       && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
+@@ -28,7 +28,7 @@
+ #error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
+ #endif
+ 
+-#line 1 "cfns.gperf"
++#line 3 "cfns.gperf"
+ 
+ /* Copyright (C) 2000-2015 Free Software Foundation, Inc.
+ 
+@@ -47,26 +47,19 @@ for more details.
+ You should have received a copy of the GNU General Public License
+ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+-#ifdef __GNUC__
+-__inline
+-#endif
+-static unsigned int hash (const char *, unsigned int);
+-#ifdef __GNUC__
+-__inline
+-#endif
+-const char * libc_name_p (const char *, unsigned int);
+ /* maximum key range = 391, duplicates = 0 */
+ 
+-#ifdef __GNUC__
+-__inline
+-#else
+-#ifdef __cplusplus
+-inline
+-#endif
+-#endif
+-static unsigned int
+-hash (register const char *str, register unsigned int len)
++class libc_name
+ {
++private:
++  static inline unsigned int hash (const char *str, unsigned int len);
++public:
++  static const char *libc_name_p (const char *str, unsigned int len);
++};
++
++inline unsigned int
++libc_name::hash (register const char *str, register unsigned int len)
++{
+   static const unsigned short asso_values[] =
+     {
+       400, 400, 400, 400, 400, 400, 400, 400, 400, 400,
+@@ -122,14 +115,8 @@ along with GCC; see the file COPYING3.  If not see
+   return hval + asso_values[(unsigned char)str[len - 1]];
+ }
+ 
+-#ifdef __GNUC__
+-__inline
+-#ifdef __GNUC_STDC_INLINE__
+-__attribute__ ((__gnu_inline__))
+-#endif
+-#endif
+ const char *
+-libc_name_p (register const char *str, register unsigned int len)
++libc_name::libc_name_p (register const char *str, register unsigned int len)
+ {
+   enum
+     {
+Index: gcc-4.9.2/gcc/cp/except.c
+===================================================================
+--- gcc-4.9.2/gcc/cp/except.c	(revision 233574)
++++ gcc-4.9.2/gcc/cp/except.c	(working copy)
+@@ -1030,7 +1030,8 @@ nothrow_libfn_p (const_tree fn)
+      unless the system headers are playing rename tricks, and if
+      they are, we don't want to be confused by them.  */
+   id = DECL_NAME (fn);
+-  return !!libc_name_p (IDENTIFIER_POINTER (id), IDENTIFIER_LENGTH (id));
++  return !!libc_name::libc_name_p (IDENTIFIER_POINTER (id),
++				   IDENTIFIER_LENGTH (id));
+ }
+ 
+ /* Returns nonzero if an exception of type FROM will be caught by a
+


### PR DESCRIPTION
Per mailing list, and discussion in irc.  Patch to help enable building Akaros GCC with GCC 6.

Tested with GCC 6.